### PR TITLE
fix:修复导包时不能使用原库名称react-native-credit-card-input引入组件

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,14 @@
   "homepage": "https://github.com/sbycrosz/react-native-credit-card-input#readme",
   "dependencies": {
     "card-validator": "^3.0.0",
-	"deprecated-react-native-prop-types": "^5.0.0",
-    "prop-types": "^15.6.0",
-    "react-native-flip-card": "^3.4.1",
+    "deprecated-react-native-prop-types": "^5.0.0",
     "lodash.compact": "^3.0.1",
     "lodash.every": "^4.6.0",
     "lodash.pick": "^4.4.0",
-    "lodash.values": "^4.3.0"
+    "lodash.values": "^4.3.0",
+    "prop-types": "^15.6.0",
+    "react-native-credit-card-input": "^0.4.1",
+    "react-native-flip-card": "^3.4.1"
   },
   "devDependencies": {
     "babel-eslint": "^5.0.0",
@@ -49,5 +50,8 @@
     "eslint": "~2.2.0",
     "eslint-config-airbnb": "6.0.2",
     "eslint-plugin-react": "^4.2.0"
+  },
+  "harmony": {
+    "alias": "react-native-credit-card-input"
   }
 }


### PR DESCRIPTION
# Summary
Closes#[5](https://github.com/react-native-oh-library/react-native-credit-card-input/issues/5)
修复
导包时不能使用原库名称react-native-credit-card-input引入组件
## Test Plan
![验证功能](https://github.com/user-attachments/assets/9255907c-0e3d-4db6-a8b7-44fcd3365072)

## Checklist

- [x] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [X] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
